### PR TITLE
create a importer base

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ env:
   RUBY_VERSION: 3.3.4
   NODE_VERSION: 22.14.0
   SHAKAPACKER_RUNTIME_COMPILE: "false"
+  DECIDIM_AVAILABLE_LOCALES: en,ca,es,pt-BR
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,6 @@ env:
   RUBY_VERSION: 3.3.4
   NODE_VERSION: 22.14.0
   SHAKAPACKER_RUNTIME_COMPILE: "false"
-  DECIDIM_AVAILABLE_LOCALES: "en,ca,es,pt-BR"
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
           chrome-version: 136.0.7103.92
 
       - run: |
-          sudo apt install wkhtmltopdf imagemagick 7zip
+          sudo apt install imagemagick
 
       - name: Setup Database
         run: bundle exec rake test_app

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ env:
   RUBY_VERSION: 3.3.4
   NODE_VERSION: 22.14.0
   SHAKAPACKER_RUNTIME_COMPILE: "false"
+  DECIDIM_AVAILABLE_LOCALES: "en,ca,es,pt-BR"
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
           chrome-version: 136.0.7103.92
 
       - run: |
-          sudo apt install imagemagick
+          sudo apt-get update; sudo apt-get -f install wkhtmltopdf imagemagick p7zip
 
       - name: Setup Database
         run: bundle exec rake test_app

--- a/README.md
+++ b/README.md
@@ -47,6 +47,132 @@ Decidim::CommunityTemplates.configure do |config|
 end
 ```
 
+## Templating specification
+
+This module allows you to create, export, and import templates for Decidim participatory spaces. Templates are structured as directories containing JSON data files, translations, and assets.
+
+### Template Structure
+
+A template is organized as a folder with the following structure:
+
+```
+template-id/
+├── data.json           # Main template data and metadata
+├── demo.json           # Optional demo data
+├── locales/            # Translation files
+│   ├── en.yml
+│   ├── es.yml
+│   └── ...
+└── assets/             # Static assets (images, documents, etc.)
+    └── demo.jpg
+```
+
+### Template Files
+
+#### `data.json`
+Contains the template metadata and model attributes:
+
+```json
+{
+  "id": "pp-template-001",
+  "class": "Decidim::ParticipatoryProcess",
+  "original_id": 1,
+  "name": "pp-template-001.metadata.name",
+  "description": "pp-template-001.metadata.description",
+  "version": "1.0.0",
+  "decidim_version": "0.30.1",
+  "community_templates_version": "0.0.1",
+  "attributes": {
+    "title": "pp-template-001.attributes.title",
+    "subtitle": "pp-template-001.attributes.subtitle",
+    "short_description": "pp-template-001.attributes.short_description",
+    "description": "pp-template-001.attributes.description"
+  }
+}
+```
+
+- `id`: Unique template identifier
+- `class`: Decidim model class name (e.g., `Decidim::ParticipatoryProcess`)
+- `name`/`description`: Reference keys for translated metadata
+- `attributes`: Model-specific attributes with translation keys. For non-translatable fields the value applies directly.
+
+#### Translation Files (`locales/*.yml`)
+Contains all translatable content, note that this follow the same specification as the I18n standard Rails library:
+
+```yaml
+en:
+  pp-template-001:
+    metadata:
+      name: "Community Participation Template"
+      description: "A template for community engagement processes"
+    attributes:
+      title: "Community Voices Initiative"
+      subtitle: "Engaging citizens in local decision-making"
+      short_description: "Join us in shaping our community's future"
+      description: "A comprehensive participatory process..."
+```
+
+#### `demo.json` (Optional)
+Contains demo data for testing and preview purposes.
+
+#### `assets/` (Optional)
+Static files like images, documents, or other resources referenced by the template.
+
+### Creating Templates
+
+Templates can be created programmatically using serializers:
+
+```ruby
+# Export a participatory process as a template
+serializer = Decidim::CommunityTemplates::Serializers::ParticipatoryProcess.init(
+  model: participatory_process,
+  metadata: {
+    name: { en: "My Template", es: "Mi Plantilla" },
+    description: { en: "Template description", es: "Descripción de la plantilla" },
+    version: "1.0.0"
+  },
+  locales: [:en, :es],
+  with_manifest: true
+)
+
+# Save to filesystem
+serializer.save!("/path/to/templates")
+```
+
+### Importing Templates
+
+Templates can be imported using the admin interface or programmatically:
+
+```ruby
+# Parse a template
+parser = Decidim::CommunityTemplates::TemplateParser.new(
+  data: {
+    "id": "some-id",
+    ...
+  },
+  translations: {
+    "en" => {
+      "some-id" => {
+        ...
+      }
+    }
+  },
+  locales: ["en", "es"]
+)
+
+# Import the template
+importer = Decidim::CommunityTemplates::Importers::ParticipatoryProcess.new(
+  parser, organization, user
+)
+importer.import!
+```
+
+A helper class for parsing the files generated in a template folder is also available:
+
+```ruby
+parser = TemplateExtractor.parse("/path/to/templates/some-id", ["en", "es"])
+```
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/decidim-ice/decidim-module-community_templates.

--- a/Rakefile
+++ b/Rakefile
@@ -9,23 +9,10 @@ def seed_db(path)
 end
 
 desc "Generates a dummy app for testing"
-task :test_app do
+task test_app: "decidim:generate_external_test_app" do
   ENV["RAILS_ENV"] = "test"
-  generate_decidim_app(
-    "spec/decidim_dummy_app",
-    "--app_name",
-    "#{base_app_name}_test_app",
-    "--path",
-    "../..",
-    "--recreate_db",
-    "--skip_gemfile",
-    "--skip_spring",
-    "--demo",
-    "--force_ssl",
-    "false",
-    "--locales",
-    "en,ca,es,pt-BR"
-  )
+  # replace languages in config/initializers/decidim.rb
+  system("sed -i 's/en ca es/en ca es pt-BR/' spec/decidim_dummy_app/config/initializers/decidim.rb")
 end
 
 desc "Generates a development app."

--- a/Rakefile
+++ b/Rakefile
@@ -9,8 +9,23 @@ def seed_db(path)
 end
 
 desc "Generates a dummy app for testing"
-task test_app: "decidim:generate_external_test_app" do
+task :test_app do
   ENV["RAILS_ENV"] = "test"
+  generate_decidim_app(
+    "spec/decidim_dummy_app",
+    "--app_name",
+    "#{base_app_name}_test_app",
+    "--path",
+    "../..",
+    "--recreate_db",
+    "--skip_gemfile",
+    "--skip_spring",
+    "--demo",
+    "--force_ssl",
+    "false",
+    "--locales",
+    "en,ca,es,pt-BR"
+  )
 end
 
 desc "Generates a development app."

--- a/app/commands/decidim/community_templates/admin/import_template.rb
+++ b/app/commands/decidim/community_templates/admin/import_template.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Decidim
+  module CommunityTemplates
+    module Admin
+      class ImportTemplate < Decidim::Command
+        def initialize(form)
+          @form = form
+          @organization = form.context.current_organization
+          @user = form.context.current_user
+        end
+        attr_reader :form, :organization, :user
+
+        def call
+          return broadcast(:invalid, form.errors.full_messages.to_sentence) if form.invalid?
+
+          importer.import!
+          broadcast(:ok)
+        rescue StandardError => e
+          return broadcast(:invalid, e.message)
+        end
+
+        private
+
+        def importer
+          @importer ||= "Decidim::CommunityTemplates::Importers::#{importer_class}".constantize.new(form.parser, organization, user, demo: form.demo)
+        end
+
+        # a very naive way to get the importer class from the metadata
+        # we might want to create a registry of importers instead
+        def importer_class
+          form.parser.metadata["class"].split("::").last
+        end
+      end
+    end
+  end
+end

--- a/app/commands/decidim/community_templates/admin/import_template.rb
+++ b/app/commands/decidim/community_templates/admin/import_template.rb
@@ -14,8 +14,10 @@ module Decidim
         def call
           return broadcast(:invalid, form.errors.full_messages.to_sentence) if form.invalid?
 
-          importer.import!
-          broadcast(:ok)
+          transaction do
+            importer.import!
+          end
+          broadcast(:ok, importer.object)
         rescue StandardError => e
           return broadcast(:invalid, e.message)
         end

--- a/app/controllers/decidim/community_templates/admin/templates_controller.rb
+++ b/app/controllers/decidim/community_templates/admin/templates_controller.rb
@@ -97,8 +97,11 @@ module Decidim
         def templates
           locales = ([I18n.locale.to_s, current_organization.default_locale.to_s] + current_organization.available_locales.map(&:to_s)).uniq
 
-          Dir.glob("#{Decidim::CommunityTemplates.local_path}/#{tab_path}/*/data.json").map do |template_file|
-            TemplateParser.new(File.dirname(template_file), locales)
+          TemplateExtractor.collection_from("#{Decidim::CommunityTemplates.local_path}/#{tab_path}", locales).map do |item|
+            {
+              path: item[:path].gsub(%r{^#{Decidim::CommunityTemplates.local_path}/}, ""),
+              parser: item[:parser]
+            }
           end
         end
       end

--- a/app/controllers/decidim/community_templates/admin/templates_controller.rb
+++ b/app/controllers/decidim/community_templates/admin/templates_controller.rb
@@ -50,12 +50,13 @@ module Decidim
           end
         end
 
+        # imports a template into the current organization (or a tenant if demo mode)
         def update
           @form = form(ImportTemplateForm).from_params(params)
 
           ImportTemplate.call(@form) do
-            on(:ok) do |_participatory_space|
-              redirect_to template_path(tab), notice: I18n.t("decidim.community_templates.admin.templates.apply.success")
+            on(:ok) do |participatory_space|
+              redirect_to participatory_space_path(participatory_space), notice: I18n.t("decidim.community_templates.admin.templates.apply.success")
             end
 
             on(:invalid) do |errors|
@@ -103,6 +104,10 @@ module Decidim
               parser: item[:parser]
             }
           end
+        end
+
+        def participatory_space_path(participatory_space)
+          Decidim::EngineRouter.admin_proxy(participatory_space).send("edit_#{participatory_space.manifest.route_name}_path", participatory_space.slug)
         end
       end
     end

--- a/app/controllers/decidim/community_templates/admin/templates_controller.rb
+++ b/app/controllers/decidim/community_templates/admin/templates_controller.rb
@@ -29,6 +29,11 @@ module Decidim
           return redirect_to templates_path, alert: t(".serializer_not_found") if @form.serializer.blank?
         end
 
+        # shows the template details, and allows to import it into the current organization (or a tenant if demo mode)
+        def edit
+          @form = form(ImportTemplateForm).from_params(params)
+        end
+
         # creates a new template from a participatory space and passed metadata
         def create
           @form = form(TemplateForm).from_params(params)
@@ -41,6 +46,20 @@ module Decidim
             on(:invalid) do |errors|
               flash.now[:alert] = I18n.t("decidim.community_templates.admin.templates.create.error", errors:)
               render :new
+            end
+          end
+        end
+
+        def update
+          @form = form(ImportTemplateForm).from_params(params)
+          ImportTemplate.call(@form) do
+            on(:ok) do |participatory_space|
+              redirect_to decidim.admin_participatory_space_path(participatory_space), notice: I18n.t("decidim.community_templates.admin.templates.edit.success")
+            end
+
+            on(:invalid) do |errors|
+              flash.now[:alert] = I18n.t("decidim.community_templates.admin.templates.edit.error", errors:)
+              render :edit
             end
           end
         end

--- a/app/controllers/decidim/community_templates/admin/templates_controller.rb
+++ b/app/controllers/decidim/community_templates/admin/templates_controller.rb
@@ -30,7 +30,7 @@ module Decidim
         end
 
         # shows the template details, and allows to import it into the current organization (or a tenant if demo mode)
-        def edit
+        def apply
           @form = form(ImportTemplateForm).from_params(params)
         end
 
@@ -52,14 +52,15 @@ module Decidim
 
         def update
           @form = form(ImportTemplateForm).from_params(params)
+
           ImportTemplate.call(@form) do
-            on(:ok) do |participatory_space|
-              redirect_to decidim.admin_participatory_space_path(participatory_space), notice: I18n.t("decidim.community_templates.admin.templates.edit.success")
+            on(:ok) do |_participatory_space|
+              redirect_to template_path(tab), notice: I18n.t("decidim.community_templates.admin.templates.apply.success")
             end
 
             on(:invalid) do |errors|
-              flash.now[:alert] = I18n.t("decidim.community_templates.admin.templates.edit.error", errors:)
-              render :edit
+              flash.now[:alert] = I18n.t("decidim.community_templates.admin.templates.apply.error", errors:)
+              render :apply
             end
           end
         end

--- a/app/forms/decidim/community_templates/admin/import_template_form.rb
+++ b/app/forms/decidim/community_templates/admin/import_template_form.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Decidim
+  module CommunityTemplates
+    module Admin
+      class ImportTemplateForm < Decidim::Form
+        attribute :id, String
+        attribute :demo, Boolean, default: false
+
+        def path
+          @path ||= id.split("_").first
+        end
+
+        def template_id
+          @template_id ||= id.split("_").last
+        end
+
+        def template_path
+          @template_path ||= "#{Decidim::CommunityTemplates.local_path}/#{path}/#{template_id}"
+        end
+
+        def locales
+          @locales ||= ([context.current_organization.default_locale.to_s] + context.current_organization.available_locales.map(&:to_s)).uniq
+        end
+
+        def parser
+          @parser ||= Decidim::CommunityTemplates::TemplateParser.new(template_path, locales)
+        end
+      end
+    end
+  end
+end

--- a/app/forms/decidim/community_templates/admin/import_template_form.rb
+++ b/app/forms/decidim/community_templates/admin/import_template_form.rb
@@ -16,7 +16,7 @@ module Decidim
         end
 
         def parser
-          @parser ||= Decidim::CommunityTemplates::TemplateParser.new(template_path, locales)
+          @parser ||= TemplateExtractor.parse(template_path, locales)
         end
       end
     end

--- a/app/forms/decidim/community_templates/admin/import_template_form.rb
+++ b/app/forms/decidim/community_templates/admin/import_template_form.rb
@@ -7,16 +7,8 @@ module Decidim
         attribute :id, String
         attribute :demo, Boolean, default: false
 
-        def path
-          @path ||= id.split("_").first
-        end
-
-        def template_id
-          @template_id ||= id.split("_").last
-        end
-
         def template_path
-          @template_path ||= "#{Decidim::CommunityTemplates.local_path}/#{path}/#{template_id}"
+          @template_path ||= "#{Decidim::CommunityTemplates.local_path}/#{id}"
         end
 
         def locales

--- a/app/services/decidim/community_templates/importer_base.rb
+++ b/app/services/decidim/community_templates/importer_base.rb
@@ -21,6 +21,7 @@ module Decidim
       end
 
       def slugify(text)
+        text = text.values.first if text.is_a?(Hash)
         base_slug = text.to_s.parameterize
         slug = base_slug
         count = 2

--- a/app/services/decidim/community_templates/importer_base.rb
+++ b/app/services/decidim/community_templates/importer_base.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Decidim
+  module CommunityTemplates
+    class ImporterBase
+      def initialize(parser, organization, user, demo: false)
+        @parser = parser
+        @organization = organization
+        @user = user
+        @demo = demo
+      end
+
+      attr_reader :parser, :organization, :user, :demo
+
+      def import!
+        raise NotImplementedError, "You must implement the import! method in your importer"
+      end
+
+      def locales
+        organization.available_locales
+      end
+
+      def slugify(text)
+        base_slug = text.to_s.parameterize
+        slug = base_slug
+        count = 2
+
+        while parser.model_class.exists?(slug:, organization:)
+          slug = "#{base_slug}-#{count}"
+          count += 1
+        end
+
+        slug
+      end
+    end
+  end
+end

--- a/app/services/decidim/community_templates/importer_base.rb
+++ b/app/services/decidim/community_templates/importer_base.rb
@@ -3,14 +3,15 @@
 module Decidim
   module CommunityTemplates
     class ImporterBase
-      def initialize(parser, organization, user, demo: false)
+      def initialize(parser, organization, user, demo: false, parent: nil)
         @parser = parser
         @organization = organization
         @user = user
         @demo = demo
+        @parent = parent
       end
 
-      attr_reader :parser, :organization, :user, :demo
+      attr_reader :parser, :organization, :user, :demo, :parent, :object
 
       def import!
         raise NotImplementedError, "You must implement the import! method in your importer"
@@ -26,7 +27,7 @@ module Decidim
         slug = base_slug
         count = 2
 
-        while parser.model_class.exists?(slug:, organization:)
+        while parser.model_class.unscoped.exists?(slug:, organization:)
           slug = "#{base_slug}-#{count}"
           count += 1
         end

--- a/app/services/decidim/community_templates/importers/component.rb
+++ b/app/services/decidim/community_templates/importers/component.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Decidim
+  module CommunityTemplates
+    module Importers
+      class ParticipatoryProcess < ImporterBase
+        def import!
+          Decidim::Component.create!(
+            participatory_space:,
+            name: parser.model_name(locales)
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/services/decidim/community_templates/importers/component.rb
+++ b/app/services/decidim/community_templates/importers/component.rb
@@ -3,12 +3,25 @@
 module Decidim
   module CommunityTemplates
     module Importers
-      class ParticipatoryProcess < ImporterBase
+      class Component < ImporterBase
         def import!
-          Decidim::Component.create!(
-            participatory_space:,
-            name: parser.model_name(locales)
+          @object = Decidim::Component.create!(
+            participatory_space: parent.object,
+            name: parser.model_name(locales),
+            manifest_name: parser.model_manifest_name,
+            settings:,
+            weight: parser.model_weight
           )
+        end
+
+        def settings
+          return {} unless parser.model_settings(locales).is_a?(Hash)
+
+          parser.attributes["settings"].dup.transform_values do |scoped_settings|
+            scoped_settings.each do |setting|
+              setting["value"] = parser.all_translations_for(setting["value"], locales) if setting["value"].is_a?(String) && setting["value"].start_with?("#{parser.id}.settings.")
+            end
+          end
         end
       end
     end

--- a/app/services/decidim/community_templates/importers/participatory_process.rb
+++ b/app/services/decidim/community_templates/importers/participatory_process.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Decidim
+  module CommunityTemplates
+    module Importers
+      class ParticipatoryProcess < ImporterBase
+        def import!
+          Decidim::ParticipatoryProcess.create!(
+            organization:,
+            title: parser.model_title(locales),
+            slug: slugify(parser.model_title)
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/services/decidim/community_templates/importers/participatory_process.rb
+++ b/app/services/decidim/community_templates/importers/participatory_process.rb
@@ -5,19 +5,35 @@ module Decidim
     module Importers
       class ParticipatoryProcess < ImporterBase
         def import!
-          process = Decidim::ParticipatoryProcess.create!(
+          @object = Decidim::ParticipatoryProcess.create!(
             organization:,
             title: parser.model_title(locales),
             slug: slugify(parser.model_title),
             subtitle: parser.model_subtitle(locales),
             short_description: parser.model_short_description(locales),
-            description: parser.model_description(locales)
+            description: parser.model_description(locales),
+            announcement: parser.model_announcement(locales),
+            start_date: parser.model_start_date,
+            end_date: parser.model_end_date,
+            developer_group: parser.model_developer_group(locales),
+            local_area: parser.model_local_area(locales),
+            meta_scope: parser.model_meta_scope(locales),
+            target: parser.model_target(locales),
+            participatory_scope: parser.model_participatory_scope(locales),
+            participatory_structure: parser.model_participatory_structure(locales),
+            private_space: parser.model_private_space,
+            promoted: parser.model_promoted
           )
-          parser.components.each do |component_data|
-            component_data[:participatory_space] = process
-            Decidim::CommunityTemplates::Importers::Component.new(parser, organization, user, demo:).import!
+
+          parser.attributes["components"].each do |component_data|
+            component_parser = TemplateParser.new(
+              data: component_data,
+              translations: parser.translations,
+              locales: parser.locales
+            )
+            Decidim::CommunityTemplates::Importers::Component.new(component_parser, organization, user, parent: self, demo:).import!
           end
-          process
+          @object
         end
       end
     end

--- a/app/services/decidim/community_templates/importers/participatory_process.rb
+++ b/app/services/decidim/community_templates/importers/participatory_process.rb
@@ -5,7 +5,7 @@ module Decidim
     module Importers
       class ParticipatoryProcess < ImporterBase
         def import!
-          Decidim::ParticipatoryProcess.create!(
+          process = Decidim::ParticipatoryProcess.create!(
             organization:,
             title: parser.model_title(locales),
             slug: slugify(parser.model_title),
@@ -13,6 +13,11 @@ module Decidim
             short_description: parser.model_short_description(locales),
             description: parser.model_description(locales)
           )
+          parser.components.each do |component_data|
+            component_data[:participatory_space] = process
+            Decidim::CommunityTemplates::Importers::Component.new(parser, organization, user, demo:).import!
+          end
+          process
         end
       end
     end

--- a/app/services/decidim/community_templates/importers/participatory_process.rb
+++ b/app/services/decidim/community_templates/importers/participatory_process.rb
@@ -8,7 +8,10 @@ module Decidim
           Decidim::ParticipatoryProcess.create!(
             organization:,
             title: parser.model_title(locales),
-            slug: slugify(parser.model_title)
+            slug: slugify(parser.model_title),
+            subtitle: parser.model_subtitle(locales),
+            short_description: parser.model_short_description(locales),
+            description: parser.model_description(locales)
           )
         end
       end

--- a/app/services/decidim/community_templates/importers/participatory_process.rb
+++ b/app/services/decidim/community_templates/importers/participatory_process.rb
@@ -25,7 +25,7 @@ module Decidim
             promoted: parser.model_promoted
           )
 
-          parser.attributes["components"].each do |component_data|
+          parser.attributes["components"]&.each do |component_data|
             component_parser = TemplateParser.new(
               data: component_data,
               translations: parser.translations,

--- a/app/services/decidim/community_templates/serializer_base.rb
+++ b/app/services/decidim/community_templates/serializer_base.rb
@@ -41,7 +41,7 @@ module Decidim
         translations
       end
 
-      # A unique random identifier for the serialized object
+      # A unique random identifier with very low collision probability for the serialized object
       def id
         return metadata[:id] if metadata[:id].present?
 

--- a/app/services/decidim/community_templates/serializer_base.rb
+++ b/app/services/decidim/community_templates/serializer_base.rb
@@ -119,7 +119,7 @@ module Decidim
 
       def i18n_field(field, value = nil, prefix = "attributes")
         value ||= model.send(field)
-        translations.deep_merge!(hash_to_i18n(value, field))
+        translations.deep_merge!(hash_to_i18n(value, field, prefix))
 
         "#{id}.#{prefix}.#{field}"
       end

--- a/app/services/decidim/community_templates/serializers/component.rb
+++ b/app/services/decidim/community_templates/serializers/component.rb
@@ -9,18 +9,16 @@ module Decidim
             manifest_name: model.manifest_name,
             name: i18n_field(:name),
             settings:,
-            weight: model.weight,
-            permissions: model.permissions,
-            visible: model.visible
+            weight: model.weight
           }
         end
 
         def settings
-          [:global, :step].flat_map do |scope|
+          [:global, :step].index_with do |scope|
             model.manifest.settings(scope).attributes.map do |type, value|
               {
                 type: type.to_s,
-                value: value.translated? ? i18n_field(type, model.settings[type], "attributes.settings") : model.settings[type]
+                value: value.translated? ? i18n_field(type, model.settings[type], "settings") : model.settings[type]
               }
             end
           end

--- a/app/services/decidim/community_templates/serializers/participatory_process.rb
+++ b/app/services/decidim/community_templates/serializers/participatory_process.rb
@@ -8,7 +8,6 @@ module Decidim
           {
             title: i18n_field(:title),
             subtitle: i18n_field(:subtitle),
-            weight: model.weight,
             slug: model.slug,
             short_description: i18n_field(:short_description),
             description: i18n_field(:description),

--- a/app/services/decidim/community_templates/template_extractor.rb
+++ b/app/services/decidim/community_templates/template_extractor.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module Decidim
+  module CommunityTemplates
+    class TemplateExtractor
+      def initialize(template_path, locales)
+        @template_path = template_path
+        @locales = locales
+        @translations_path = File.join(@template_path, "locales")
+      end
+      attr_reader :template_path, :translations_path, :locales
+
+      def data
+        @data ||= JSON.parse(File.read(File.join(@template_path, "data.json")))
+      end
+
+      def translations
+        @translations ||= if Dir.exist?(@translations_path)
+                            locales.each_with_object({}) do |lang, hash|
+                              file = File.join(@translations_path, "#{lang}.yml")
+                              next unless File.exist?(file)
+
+                              hash[lang] = YAML.load_file(file)[lang] || {}
+                            end
+                          else
+                            {}
+                          end
+      end
+
+      def self.extract(template_path, locales = Decidim.available_locales.map(&:to_s))
+        template = new(template_path, locales)
+        {
+          data: template.data,
+          translations: template.translations,
+          locales: locales
+        }
+      end
+
+      def self.parse(template_path, locales = Decidim.available_locales.map(&:to_s))
+        TemplateParser.new(**extract(template_path, locales))
+      end
+
+      def self.collection_from(glob_path, locales = Decidim.available_locales.map(&:to_s))
+        Dir.glob("#{glob_path}/*/data.json").map do |template_file|
+          path = File.dirname(template_file)
+          {
+            path:,
+            parser: parse(path, locales)
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/services/decidim/community_templates/template_parser.rb
+++ b/app/services/decidim/community_templates/template_parser.rb
@@ -64,7 +64,7 @@ module Decidim
 
             locales_array = args.first
             return locales_array.index_with do |locale|
-              translations.dig(locale, *value.to_s.split(".")) || value
+              translations.dig(locale, *value.to_s.split(".")) || ""
             end
 
             # Otherwise, return the translation in the first locale available

--- a/app/services/decidim/community_templates/template_parser.rb
+++ b/app/services/decidim/community_templates/template_parser.rb
@@ -44,13 +44,13 @@ module Decidim
       def method_missing(method, *args, &)
         if method.to_s.start_with?("model_")
           key = method.to_s.sub("model_", "")
-          if attributes.has_key?(key)
-            value = attributes[key]
-            # If an array of locales is given as argument, return a hash with translations
-            return translation_for(value) unless args.first.is_a?(Array)
+          return nil unless attributes.has_key?(key)
 
-            return all_translations_for(value, args.first)
-          end
+          value = attributes[key]
+          # If an array of locales is given as argument, return a hash with translations
+          return translation_for(value) unless args.first.is_a?(Array)
+
+          return all_translations_for(value, args.first)
         end
         super
       end

--- a/app/services/decidim/community_templates/template_parser.rb
+++ b/app/services/decidim/community_templates/template_parser.rb
@@ -3,16 +3,16 @@
 module Decidim
   module CommunityTemplates
     class TemplateParser
-      def initialize(template_path, locales = Decidim.available_locales.map(&:to_s))
-        @template_path = template_path
-        @translations_path = File.join(@template_path, "locales")
+      def initialize(data:, translations: {}, locales: Decidim.available_locales.map(&:to_s))
+        @data = data
+        @translations = translations
         @locales = locales
       end
 
-      attr_reader :template_path, :translations_path, :locales
+      attr_reader :data, :translations, :locales
 
       def id
-        @id ||= metadata["id"] || File.basename(@template_path)
+        @id ||= metadata["id"]
       end
 
       def model_class
@@ -29,19 +29,6 @@ module Decidim
 
       def version
         metadata["version"]
-      end
-
-      def translations
-        @translations ||= if Dir.exist?(@translations_path)
-                            locales.each_with_object({}) do |lang, hash|
-                              file = File.join(@translations_path, "#{lang}.yml")
-                              next unless File.exist?(file)
-
-                              hash[lang] = YAML.load_file(file)[lang] || {}
-                            end
-                          else
-                            {}
-                          end
       end
 
       def metadata
@@ -80,18 +67,6 @@ module Decidim
           return true if attributes.has_key?(key)
         end
         super
-      end
-
-      def data
-        @data ||= JSON.parse(File.read(File.join(@template_path, "data.json")))
-      end
-
-      def demo
-        @demo ||= if File.exist?(File.join(@template_path, "demo.json"))
-                    JSON.parse(File.read(File.join(@template_path, "demo.json")))
-                  else
-                    {}
-                  end
       end
 
       def translation_for(field)

--- a/app/services/decidim/community_templates/template_parser.rb
+++ b/app/services/decidim/community_templates/template_parser.rb
@@ -49,13 +49,7 @@ module Decidim
             # If an array of locales is given as argument, return a hash with translations
             return translation_for(value) unless args.first.is_a?(Array)
 
-            locales_array = args.first
-            return locales_array.index_with do |locale|
-              translations.dig(locale, *value.to_s.split(".")) || ""
-            end
-
-            # Otherwise, return the translation in the first locale available
-
+            return all_translations_for(value, args.first)
           end
         end
         super
@@ -69,12 +63,16 @@ module Decidim
         super
       end
 
-      def translation_for(field)
-        return unless field
+      def all_translations_for(field, locales)
+        locales.index_with do |locale|
+          translations.dig(locale, *field.to_s.split(".")) || ""
+        end
+      end
 
-        find_translation(field) || metadata[field]
-      rescue StandardError
-        metadata[field]
+      def translation_for(field)
+        return unless field && field.is_a?(String)
+
+        find_translation(field) || field
       end
 
       private

--- a/app/views/decidim/community_templates/admin/templates/_edit_template_form.html.erb
+++ b/app/views/decidim/community_templates/admin/templates/_edit_template_form.html.erb
@@ -2,7 +2,7 @@
   <div class="row column pt-4">
     <div class="item_show__header">
       <h2 class="item_show__header-title">
-        <%= t("decidim.community_templates.admin.templates.edit.title") %>
+        <%= t("decidim.community_templates.admin.templates.apply.title") %>
       </h2>
     </div>
   </div>
@@ -18,11 +18,11 @@
         TODO: show info about the objects that will be imported with this template
       </div>
       <div class="row column">
-          <%= f.check_box :demo, label: t("decidim.community_templates.admin.templates.edit.demo") %>
+          <%= f.check_box :demo, label: t("decidim.community_templates.admin.templates.apply.demo") %>
       </div>
 
       <div class="row column">
-        <%= f.submit t("decidim.community_templates.admin.templates.edit.submit"), class: "button button__sm button__secondary" %>
+        <%= f.submit t("decidim.community_templates.admin.templates.apply.submit"), class: "button button__sm button__secondary" %>
       </div>
     <% end %>
   </div>

--- a/app/views/decidim/community_templates/admin/templates/_edit_template_form.html.erb
+++ b/app/views/decidim/community_templates/admin/templates/_edit_template_form.html.erb
@@ -1,0 +1,29 @@
+<div class="card">
+  <div class="row column pt-4">
+    <div class="item_show__header">
+      <h2 class="item_show__header-title">
+        <%= t("decidim.community_templates.admin.templates.edit.title") %>
+      </h2>
+    </div>
+  </div>
+
+  <div class="form__wrapper">
+    <%= decidim_form_for @form, url: template_path(@form.id), method: :put, html: { class: "form-defaults form new_template" } do |f| %>
+      <%= f.hidden_field :id %>
+      <div class="row column">
+        <h3 class="h4"><%= translated_attribute(@form.parser.name) %></h3>
+        <p><%= translated_attribute(@form.parser.description) %> (<%= @form.parser.version %>)</p>
+      </div>
+      <div class="row column">
+        TODO: show info about the objects that will be imported with this template
+      </div>
+      <div class="row column">
+          <%= f.check_box :demo, label: t("decidim.community_templates.admin.templates.edit.demo") %>
+      </div>
+
+      <div class="row column">
+        <%= f.submit t("decidim.community_templates.admin.templates.edit.submit"), class: "button button__sm button__secondary" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/decidim/community_templates/admin/templates/_new_template_form.html.erb
+++ b/app/views/decidim/community_templates/admin/templates/_new_template_form.html.erb
@@ -26,11 +26,11 @@
       </div>
 
       <div class="row column">
-        <%= f.translated :text_field, :name, label: t("decidim.community_templates.admin.templates.new.metadata.name") %>
+        <%= f.translated :text_field, :name, label: t("decidim.community_templates.admin.templates.new.metadata.name"), aria: { label: :name } %>
       </div>
 
       <div class="row column">
-        <%= f.translated :text_area, :description, label: t("decidim.community_templates.admin.templates.new.metadata.description"), placeholder: t("decidim.community_templates.admin.templates.new.metadata.description_placeholder") %>
+        <%= f.translated :text_area, :description, label: t("decidim.community_templates.admin.templates.new.metadata.description"), placeholder: t("decidim.community_templates.admin.templates.new.metadata.description_placeholder"), aria: { label: :description } %>
       </div>
 
       <div class="row column">

--- a/app/views/decidim/community_templates/admin/templates/_template.html.erb
+++ b/app/views/decidim/community_templates/admin/templates/_template.html.erb
@@ -1,11 +1,10 @@
 <div class="card my-4 p-4">
   <div class="card-section">
-    <h3 class="h5"><%= template.name %></h3>
-    <p><%= template.description %> (<%= template.version %>)</p>
+    <h3 class="h5"><%= template[:parser].name %></h3>
+    <p><%= template[:parser].description %> (<%= template[:parser].version %>)</p>
     <p>
-      <% relative_path = template.template_path.gsub(/^#{Decidim::CommunityTemplates.local_path}\//, "") %>
-      <%= link_to t("decidim.community_templates.admin.templates.template.apply"), apply_templates_path("#{relative_path}"), class: "button button__xs button__transparent-secondary" %>
-      <%= link_to t("decidim.community_templates.admin.templates.template.download"), download_templates_path("#{relative_path}"), class: "button button__xs button__transparent-secondary" %>
+      <%= link_to t("decidim.community_templates.admin.templates.template.apply"), apply_templates_path("#{template[:path]}"), class: "button button__xs button__transparent-secondary" %>
+      <%= link_to t("decidim.community_templates.admin.templates.template.download"), download_templates_path("#{template[:path]}"), class: "button button__xs button__transparent-secondary" %>
     </p>
   </div>
 </div>

--- a/app/views/decidim/community_templates/admin/templates/_template.html.erb
+++ b/app/views/decidim/community_templates/admin/templates/_template.html.erb
@@ -3,7 +3,7 @@
     <h3 class="h5"><%= template.name %></h3>
     <p><%= template.description %> (<%= template.version %>)</p>
     <p>
-      <%= link_to t("decidim.community_templates.admin.templates.template.apply"), "#", class: "button button__xs button__transparent-secondary" %>
+      <%= link_to t("decidim.community_templates.admin.templates.template.apply"), edit_template_path("#{tab_path}_#{template.id}"), class: "button button__xs button__transparent-secondary" %>
       <%= link_to t("decidim.community_templates.admin.templates.template.download"), download_templates_path("#{tab_path}/#{template.id}"), class: "button button__xs button__transparent-secondary" %>
     </p>
   </div>

--- a/app/views/decidim/community_templates/admin/templates/_template.html.erb
+++ b/app/views/decidim/community_templates/admin/templates/_template.html.erb
@@ -3,8 +3,9 @@
     <h3 class="h5"><%= template.name %></h3>
     <p><%= template.description %> (<%= template.version %>)</p>
     <p>
-      <%= link_to t("decidim.community_templates.admin.templates.template.apply"), edit_template_path("#{tab_path}_#{template.id}"), class: "button button__xs button__transparent-secondary" %>
-      <%= link_to t("decidim.community_templates.admin.templates.template.download"), download_templates_path("#{tab_path}/#{template.id}"), class: "button button__xs button__transparent-secondary" %>
+      <% relative_path = template.template_path.gsub(/^#{Decidim::CommunityTemplates.local_path}\//, "") %>
+      <%= link_to t("decidim.community_templates.admin.templates.template.apply"), apply_templates_path("#{relative_path}"), class: "button button__xs button__transparent-secondary" %>
+      <%= link_to t("decidim.community_templates.admin.templates.template.download"), download_templates_path("#{relative_path}"), class: "button button__xs button__transparent-secondary" %>
     </p>
   </div>
 </div>

--- a/app/views/decidim/community_templates/admin/templates/apply.html.erb
+++ b/app/views/decidim/community_templates/admin/templates/apply.html.erb
@@ -1,0 +1,5 @@
+<% add_decidim_page_title(t("decidim.community_templates.admin.templates.apply.title")) %>
+
+<div class="item__edit-form">
+  <%= render partial: "edit_template_form" %>
+</div>

--- a/app/views/decidim/community_templates/admin/templates/edit.html.erb
+++ b/app/views/decidim/community_templates/admin/templates/edit.html.erb
@@ -1,6 +1,0 @@
-<% add_decidim_page_title(t("decidim.community_templates.admin.templates.edit.title")) %>
-
-
-<div class="item__edit-form">
-  <%= render partial: "edit_template_form" %>
-</div>

--- a/app/views/decidim/community_templates/admin/templates/edit.html.erb
+++ b/app/views/decidim/community_templates/admin/templates/edit.html.erb
@@ -1,0 +1,6 @@
+<% add_decidim_page_title(t("decidim.community_templates.admin.templates.edit.title")) %>
+
+
+<div class="item__edit-form">
+  <%= render partial: "edit_template_form" %>
+</div>

--- a/catalog/simple-assembly/data.json
+++ b/catalog/simple-assembly/data.json
@@ -1,17 +1,14 @@
 {
   "class": "Decidim::Assembly",
   "id": "2025-0001-0001-0001",
+  "original_id": 1,
+  "name": "2025-0001-0001-0001.metadata.name",
+  "description": "2025-0001-0001-0001.metadata.description",
+  "version": "1.0.0",
+  "decidim_version": "0.30.1",
+  "community_templates_version": "0.0.1",
   "attributes": {
     "title": "2025-0001-0001-0001.attributes.title",
     "description": "2025-0001-0001-0001.attributes.description"
-  },
-  "components": [
-    { 
-      "class": "Decidim::Component",
-      "id": "0001",
-      "attributes": {
-        "name": "2025-0001-0001-0001.components.0001.attributes.name"
-      }
-    }
-  ]
+  }
 }

--- a/catalog/simple-assembly/locales/en.yml
+++ b/catalog/simple-assembly/locales/en.yml
@@ -1,5 +1,8 @@
 en:
   2025-0001-0001-0001:
+    metadata:
+      name: A simple assembly
+      description: This is a simple assembly for testing purposes.
     attributes:
       title: A simple assembly
       description: This is a simple assembly for testing purposes.

--- a/catalog/simple-participatory-process/data.json
+++ b/catalog/simple-participatory-process/data.json
@@ -1,3 +1,16 @@
 {
-  "class": "Decidim::ParticipatoryProcess"
+  "id": "2025-0001-0002-0001",
+  "class": "Decidim::ParticipatoryProcess",
+  "original_id": 1,
+  "name": "2025-0001-0002-0001.metadata.name",
+  "description": "2025-0001-0002-0001.metadata.description",
+  "version": "1.0.0",
+  "decidim_version": "0.30.1",
+  "community_templates_version": "0.0.1",
+  "attributes": {
+    "title": "2025-0001-0002-0001.attributes.title",
+    "subtitle": "2025-0001-0002-0001.attributes.subtitle",
+    "short_description": "2025-0001-0002-0001.attributes.short_description",
+    "description": "2025-0001-0002-0001.attributes.description"
+  }
 }

--- a/catalog/simple-participatory-process/locales/en.yml
+++ b/catalog/simple-participatory-process/locales/en.yml
@@ -1,7 +1,7 @@
 en:
-  pp-template-001:
+  2025-0001-0002-0001:
     metadata:
-      name: Participatory process template
+      name: A simple participatory process template
       description: A template for participatory processes
     attributes:
       title: Participatory process title

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,11 +29,11 @@ en:
             success: The template has been created successfully.
           download:
             error: There was an error generating the template zip file.
-          edit:
+          apply:
             demo: Include demo data
-            error: There was an error updating the template. %{errors}
+            error: There was an error importing the template. %{errors}
             submit: Create the new participatory space
-            success: The template has been updated successfully.
+            success: The participatory space has been created successfully.
             title: Create space from template
           index:
             create_template: Create the new template

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,17 +24,17 @@ en:
           local_templates: Local templates
           manage_catalogs: Manage catalogs
         templates:
-          create:
-            error: There was an error creating the template. %{errors}
-            success: The template has been created successfully.
-          download:
-            error: There was an error generating the template zip file.
           apply:
             demo: Include demo data
             error: There was an error importing the template. %{errors}
             submit: Create the new participatory space
             success: The participatory space has been created successfully.
             title: Create space from template
+          create:
+            error: There was an error creating the template. %{errors}
+            success: The template has been created successfully.
+          download:
+            error: There was an error generating the template zip file.
           index:
             create_template: Create the new template
             new_from_space: Create a new template from a participatory space

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,6 +29,12 @@ en:
             success: The template has been created successfully.
           download:
             error: There was an error generating the template zip file.
+          edit:
+            demo: Include demo data
+            error: There was an error updating the template. %{errors}
+            submit: Create the new participatory space
+            success: The template has been updated successfully.
+            title: Create space from template
           index:
             create_template: Create the new template
             new_from_space: Create a new template from a participatory space

--- a/lib/decidim/community_templates/admin_engine.rb
+++ b/lib/decidim/community_templates/admin_engine.rb
@@ -11,6 +11,7 @@ module Decidim
       routes do
         resources :templates do
           collection do
+            get "apply/:id", to: "templates#apply", as: :apply
             get "download/:id", to: "templates#download", as: :download
           end
         end

--- a/spec/fixtures/template_test/data.json
+++ b/spec/fixtures/template_test/data.json
@@ -9,6 +9,8 @@
   "community_templates_version": "0.0.1",
   "attributes": {
     "title": "pp-template-001.attributes.title",
+    "subtitle": "pp-template-001.attributes.subtitle",
+    "short_description": "pp-template-001.attributes.short_description",
     "description": "pp-template-001.attributes.description"
   }
 }

--- a/spec/fixtures/template_test/locales/ca.yml
+++ b/spec/fixtures/template_test/locales/ca.yml
@@ -6,3 +6,5 @@ ca:
     attributes:
       title: Títol del procés participatiu
       description: Descripció del procés participatiu
+      subtitle: Subtítol del procés participatiu
+      short_description: Descripció breu del procés participatiu

--- a/spec/fixtures/template_test/locales/pt-BR.yml
+++ b/spec/fixtures/template_test/locales/pt-BR.yml
@@ -1,0 +1,10 @@
+"pt-BR":
+  pp-template-001:
+    metadata:
+      name: Template de processo participativo
+      description: Um modelo para processos participativos
+    attributes:
+      title: Título do processo participativo
+      description: Descrição do processo participativo
+      subtitle: Subtítulo do processo participativo
+      short_description: Descrição curta do processo participativo

--- a/spec/forms/admin/import_template_form_spec.rb
+++ b/spec/forms/admin/import_template_form_spec.rb
@@ -26,7 +26,7 @@ module Decidim
 
         describe "#parser" do
           it "returns a TemplateParser instance with correct path and locales" do
-            allow(subject).to receive(:template_path).and_return("spec/fixtures/template_test")
+            allow(form).to receive(:template_path).and_return("spec/fixtures/template_test")
             parser = form.parser
             expect(parser).to be_a(Decidim::CommunityTemplates::TemplateParser)
           end

--- a/spec/forms/admin/import_template_form_spec.rb
+++ b/spec/forms/admin/import_template_form_spec.rb
@@ -6,7 +6,7 @@ module Decidim
   module CommunityTemplates
     module Admin
       describe ImportTemplateForm, type: :form do
-        let(:organization) { create(:organization, default_locale: :en, available_locales: [:en, :es]) }
+        let(:organization) { create(:organization, default_locale: :en, available_locales: [:en, :"pt-BR"]) }
         let(:context) { { current_organization: organization } }
         let(:id) { "folder_123" }
         let(:form) { described_class.new(id: id, demo: true).with_context(**context) }

--- a/spec/forms/admin/import_template_form_spec.rb
+++ b/spec/forms/admin/import_template_form_spec.rb
@@ -20,7 +20,7 @@ module Decidim
 
         describe "#locales" do
           it "returns the default and available locales as strings, uniq" do
-            expect(form.locales).to match_array(%w(en es))
+            expect(form.locales).to match_array(%w(en pt-BR))
           end
         end
 

--- a/spec/forms/admin/import_template_form_spec.rb
+++ b/spec/forms/admin/import_template_form_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module CommunityTemplates
+    module Admin
+      describe ImportTemplateForm, type: :form do
+        let(:organization) { create(:organization, default_locale: :en, available_locales: [:en, :es]) }
+        let(:context) { { current_organization: organization } }
+        let(:id) { "folder_123" }
+        let(:form) { described_class.new(id: id, demo: true).with_context(**context) }
+
+        describe "#template_path" do
+          it "returns the correct template path" do
+            allow(Decidim::CommunityTemplates).to receive(:local_path).and_return("/tmp/templates")
+            expect(form.template_path).to eq("/tmp/templates/folder_123")
+          end
+        end
+
+        describe "#locales" do
+          it "returns the default and available locales as strings, uniq" do
+            expect(form.locales).to match_array(%w(en es))
+          end
+        end
+
+        describe "#parser" do
+          it "returns a TemplateParser instance with correct path and locales" do
+            allow(subject).to receive(:template_path).and_return("spec/fixtures/template_test")
+            parser = form.parser
+            expect(parser).to be_a(Decidim::CommunityTemplates::TemplateParser)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/forms/admin/template_form_spec.rb
+++ b/spec/forms/admin/template_form_spec.rb
@@ -31,8 +31,8 @@ module Decidim
             version:
           }
         end
-        let(:name) { { "ca" => "Nom", "es" => "Nombre", "en" => "Name" } }
-        let(:description) { { "ca" => "Descripció", "es" => "Descripción", "en" => "Description" } }
+        let(:name) { { "ca" => "Nom", "pt-BR" => "Nome", "en" => "Name" } }
+        let(:description) { { "ca" => "Descripció", "pt-BR" => "Descrição", "en" => "Description" } }
         let(:version) { "1.0.0" }
 
         it { is_expected.to be_valid }

--- a/spec/services/decidim/community_templates/importers/participatory_process_spec.rb
+++ b/spec/services/decidim/community_templates/importers/participatory_process_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module CommunityTemplates
+    module Importers
+      RSpec.describe ParticipatoryProcess, type: :service do
+        let(:organization) { create(:organization, available_locales: [:en, :ca]) }
+        let(:user) { create(:user, organization: organization) }
+        let(:parser) do
+          double(
+            "Parser",
+            model_class: Decidim::ParticipatoryProcess,
+            model_title: { "en" => "Test Process", "ca" => "Procés de prova" },
+            subtitle: { "en" => "Test Subtitle", "ca" => "Subtítol de prova" },
+            short_description: { "en" => "Short description", "ca" => "Descripció curta" },
+            description: { "en" => "A description", "ca" => "Una descripció" }
+          )
+        end
+
+        subject(:importer) { described_class.new(parser, organization, user) }
+
+        describe "#locales" do
+          it "returns the organization's available locales" do
+            expect(importer.locales).to eq(%w(en ca))
+          end
+        end
+
+        describe "#slugify" do
+          it "parameterizes the given text" do
+            expect(importer.slugify("Test Process")).to eq("test-process")
+          end
+
+          it "appends a number if the slug already exists" do
+            create(:participatory_process, slug: "test-process", organization: organization)
+            allow(parser).to receive(:model_class).and_return(Decidim::ParticipatoryProcess)
+            expect(importer.slugify("Test Process")).to eq("test-process-2")
+          end
+        end
+
+        describe "#import!" do
+          it "creates a new participatory process with the parsed title and a unique slug" do
+            participatory_process = importer.import!
+            expect(participatory_process).to be_persisted
+            expect(participatory_process.title).to eq({ "en" => "Test Process", "ca" => "Procés de prova" })
+            expect(participatory_process.subtitle).to eq({ "en" => "Test Subtitle", "ca" => "Subtítol de prova" })
+            expect(participatory_process.short_description).to eq({ "en" => "Short description", "ca" => "Descripció curta" })
+            expect(participatory_process.description).to eq({ "en" => "A description", "ca" => "Una descripció" })
+            expect(participatory_process.slug).to eq("test-process")
+            expect(participatory_process.organization).to eq(organization)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/decidim/community_templates/importers/participatory_process_spec.rb
+++ b/spec/services/decidim/community_templates/importers/participatory_process_spec.rb
@@ -6,7 +6,7 @@ module Decidim
   module CommunityTemplates
     module Importers
       RSpec.describe ParticipatoryProcess, type: :service do
-        let(:organization) { create(:organization, available_locales: [:en, :ca]) }
+        let(:organization) { create(:organization, available_locales: [:en, :ca, :"pt-BR"]) }
         let(:user) { create(:user, organization: organization) }
         let(:parser) do
           TemplateExtractor.parse("spec/fixtures/template_test", organization.available_locales)
@@ -16,7 +16,7 @@ module Decidim
 
         describe "#locales" do
           it "returns the organization's available locales" do
-            expect(importer.locales).to eq(%w(en ca))
+            expect(importer.locales).to eq(%w(en ca pt-BR))
           end
         end
 
@@ -36,10 +36,10 @@ module Decidim
           it "creates a new participatory process with the parsed title and a unique slug" do
             participatory_process = importer.import!
             expect(participatory_process).to be_persisted
-            expect(participatory_process.title).to eq({ "ca" => "Títol del procés participatiu", "en" => "Participatory process title" })
-            expect(participatory_process.subtitle).to eq({ "en" => "Participatory process subtitle", "ca" => "Subtítol del procés participatiu" })
-            expect(participatory_process.short_description).to eq({ "en" => "Participatory process short description", "ca" => "Descripció breu del procés participatiu" })
-            expect(participatory_process.description).to eq({ "en" => "Participatory process description", "ca" => "Descripció del procés participatiu" })
+            expect(participatory_process.title).to eq({ "ca" => "Títol del procés participatiu", "en" => "Participatory process title", "pt-BR" => "Título do processo participativo" })
+            expect(participatory_process.subtitle).to eq({ "en" => "Participatory process subtitle", "ca" => "Subtítol del procés participatiu", "pt-BR" => "Subtítulo do processo participativo" })
+            expect(participatory_process.short_description).to eq({ "en" => "Participatory process short description", "ca" => "Descripció breu del procés participatiu", "pt-BR" => "Descrição curta do processo participativo" })
+            expect(participatory_process.description).to eq({ "en" => "Participatory process description", "ca" => "Descripció del procés participatiu", "pt-BR" => "Descrição do processo participativo" })
             expect(participatory_process.slug).to eq("participatory-process-title")
             expect(participatory_process.organization).to eq(organization)
           end

--- a/spec/services/decidim/community_templates/importers/participatory_process_spec.rb
+++ b/spec/services/decidim/community_templates/importers/participatory_process_spec.rb
@@ -9,7 +9,7 @@ module Decidim
         let(:organization) { create(:organization, available_locales: [:en, :ca]) }
         let(:user) { create(:user, organization: organization) }
         let(:parser) do
-          TemplateParser.new("spec/fixtures/template_test", organization.available_locales)
+          TemplateExtractor.parse("spec/fixtures/template_test", organization.available_locales)
         end
 
         subject(:importer) { described_class.new(parser, organization, user) }

--- a/spec/services/decidim/community_templates/importers/participatory_process_spec.rb
+++ b/spec/services/decidim/community_templates/importers/participatory_process_spec.rb
@@ -9,14 +9,7 @@ module Decidim
         let(:organization) { create(:organization, available_locales: [:en, :ca]) }
         let(:user) { create(:user, organization: organization) }
         let(:parser) do
-          double(
-            "Parser",
-            model_class: Decidim::ParticipatoryProcess,
-            model_title: { "en" => "Test Process", "ca" => "Procés de prova" },
-            subtitle: { "en" => "Test Subtitle", "ca" => "Subtítol de prova" },
-            short_description: { "en" => "Short description", "ca" => "Descripció curta" },
-            description: { "en" => "A description", "ca" => "Una descripció" }
-          )
+          TemplateParser.new("spec/fixtures/template_test", organization.available_locales)
         end
 
         subject(:importer) { described_class.new(parser, organization, user) }
@@ -43,11 +36,11 @@ module Decidim
           it "creates a new participatory process with the parsed title and a unique slug" do
             participatory_process = importer.import!
             expect(participatory_process).to be_persisted
-            expect(participatory_process.title).to eq({ "en" => "Test Process", "ca" => "Procés de prova" })
-            expect(participatory_process.subtitle).to eq({ "en" => "Test Subtitle", "ca" => "Subtítol de prova" })
-            expect(participatory_process.short_description).to eq({ "en" => "Short description", "ca" => "Descripció curta" })
-            expect(participatory_process.description).to eq({ "en" => "A description", "ca" => "Una descripció" })
-            expect(participatory_process.slug).to eq("test-process")
+            expect(participatory_process.title).to eq({ "ca" => "Títol del procés participatiu", "en" => "Participatory process title" })
+            expect(participatory_process.subtitle).to eq({ "en" => "Participatory process subtitle", "ca" => "Subtítol del procés participatiu" })
+            expect(participatory_process.short_description).to eq({ "en" => "Participatory process short description", "ca" => "Descripció breu del procés participatiu" })
+            expect(participatory_process.description).to eq({ "en" => "Participatory process description", "ca" => "Descripció del procés participatiu" })
+            expect(participatory_process.slug).to eq("participatory-process-title")
             expect(participatory_process.organization).to eq(organization)
           end
         end

--- a/spec/services/decidim/community_templates/serializers/participatory_process_spec.rb
+++ b/spec/services/decidim/community_templates/serializers/participatory_process_spec.rb
@@ -47,7 +47,6 @@ module Decidim
         it "has the correct attributes" do
           expect(attributes[:title]).to eq("#{serializer.id}.attributes.title")
           expect(attributes[:subtitle]).to eq("#{serializer.id}.attributes.subtitle")
-          expect(attributes[:weight]).to eq(model.weight)
           expect(attributes[:slug]).to eq(model.slug)
           expect(attributes[:short_description]).to eq("#{serializer.id}.attributes.short_description")
           expect(attributes[:description]).to eq("#{serializer.id}.attributes.description")
@@ -109,7 +108,7 @@ module Decidim
           expect(component_data[:original_id]).to eq(component.id)
           expect(component_data[:attributes][:name]).to eq("#{serializer.id}.attributes.components.#{component.id}.attributes.name")
           expect(component_data[:attributes][:manifest_name]).to eq(component.manifest_name)
-          expect(component_data[:attributes][:settings]).to be_an(Array)
+          expect(component_data[:attributes][:settings]).to be_an(Hash)
         end
 
         it "saves the serialized data to disk" do

--- a/spec/services/decidim/community_templates/template_parser_spec.rb
+++ b/spec/services/decidim/community_templates/template_parser_spec.rb
@@ -31,6 +31,10 @@ module Decidim
         expect(metadata["original_id"]).to eq(1)
       end
 
+      it "returns the model class correctly" do
+        expect(parser.model_class).to eq(Decidim::ParticipatoryProcess)
+      end
+
       it "returns attributes correctly" do
         expect(attributes).to be_a(Hash)
 
@@ -38,6 +42,14 @@ module Decidim
         expect(parser.model_description).to eq("Participatory process description")
         expect(attributes["title"]).to eq("pp-template-001.attributes.title")
         expect(attributes["description"]).to eq("pp-template-001.attributes.description")
+      end
+
+      it "returns translations correctly for the model translatable fields" do
+        expect(parser.model_title(locales)).to eq({ "en" => "Participatory process title", "ca" => "Títol del procés participatiu" })
+        expect(parser.model_description(locales)).to eq({ "en" => "Participatory process description", "ca" => "Descripció del procés participatiu" })
+
+        expect(parser.model_title(["ca"])).to eq({ "ca" => "Títol del procés participatiu" })
+        expect(parser.model_title(["en"])).to eq({ "en" => "Participatory process title" })
       end
 
       context "when locales reversed" do

--- a/spec/services/decidim/community_templates/template_parser_spec.rb
+++ b/spec/services/decidim/community_templates/template_parser_spec.rb
@@ -5,10 +5,52 @@ require "spec_helper"
 module Decidim
   module CommunityTemplates
     describe TemplateParser do
-      let(:template_path) { "spec/fixtures/template_test" }
       let(:locales) { %w(en ca) }
-      let(:parser) { described_class.new(template_path, locales) }
-      let(:data) { parser.data }
+      let(:parser) { described_class.new(data:, translations:, locales:) }
+      let(:data) do
+        {
+          "id" => "pp-template-001",
+          "class" => "Decidim::ParticipatoryProcess",
+          "name" => "pp-template-001.metadata.name",
+          "description" => "pp-template-001.metadata.description",
+          "version" => "1.0.0",
+          "decidim_version" => "0.30.1",
+          "community_templates_version" => "0.0.1",
+          "original_id" => 1,
+          "attributes" => {
+            "title" => "pp-template-001.attributes.title",
+            "description" => "pp-template-001.attributes.description"
+          }
+        }
+      end
+      let(:translations) do
+        {
+          "en" => {
+            "pp-template-001" => {
+              "metadata" => {
+                "name" => "Participatory process template",
+                "description" => "A template for participatory processes"
+              },
+              "attributes" => {
+                "title" => "Participatory process title",
+                "description" => "Participatory process description"
+              }
+            }
+          },
+          "ca" => {
+            "pp-template-001" => {
+              "metadata" => {
+                "name" => "Plantilla de procés participatiu",
+                "description" => "Una plantilla per a processos participatius"
+              },
+              "attributes" => {
+                "title" => "Títol del procés participatiu",
+                "description" => "Descripció del procés participatiu"
+              }
+            }
+          }
+        }
+      end
       let(:metadata) { parser.metadata }
       let(:attributes) { parser.attributes }
       let(:demo) { parser.demo }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,10 @@ require "decidim/dev"
 
 ENV["ENGINE_ROOT"] = File.dirname(__dir__)
 ENV["NODE_ENV"] ||= "test"
+ENV["DECIDIM_AVAILABLE_LOCALES"] = "en,ca,es,pt-BR"
 
 Decidim::Dev.dummy_app_path = File.expand_path(File.join(__dir__, "decidim_dummy_app"))
 
 require "decidim/dev/test/base_spec_helper"
+I18n.available_locales = ENV["DECIDIM_AVAILABLE_LOCALES"].split(",").map(&:to_sym)
+Decidim.available_locales = I18n.available_locales

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,15 +8,3 @@ ENV["NODE_ENV"] ||= "test"
 Decidim::Dev.dummy_app_path = File.expand_path(File.join(__dir__, "decidim_dummy_app"))
 
 require "decidim/dev/test/base_spec_helper"
-RSpec.configure do |config|
-  # Make "pt-BR" locale available in tests.
-  config.before do
-    I18n.available_locales = [:en, :ca, :"pt-BR"]
-    Decidim.available_locales = [:en, :ca, :"pt-BR"]
-    Decidim.default_locale = :en
-  end
-
-  config.around do |example|
-    I18n.with_locale(:en) { example.run }
-  end
-end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,3 +8,15 @@ ENV["NODE_ENV"] ||= "test"
 Decidim::Dev.dummy_app_path = File.expand_path(File.join(__dir__, "decidim_dummy_app"))
 
 require "decidim/dev/test/base_spec_helper"
+RSpec.configure do |config|
+  # Make "pt-BR" locale available in tests.
+  config.before do
+    I18n.available_locales = [:en, :ca, :"pt-BR"]
+    Decidim.available_locales = [:en, :ca, :"pt-BR"]
+    Decidim.default_locale = :en
+  end
+
+  config.around do |example|
+    I18n.with_locale(:en) { example.run }
+  end
+end

--- a/spec/system/admin/admin_manages_templates_spec.rb
+++ b/spec/system/admin/admin_manages_templates_spec.rb
@@ -35,7 +35,7 @@ describe "Admin templates" do
 
     context "when there are external templates" do
       before do
-        path = "#{Decidim::CommunityTemplates.local_path}/external/template_1"
+        path = "#{Decidim::CommunityTemplates.local_path}/external/pp-template-001"
         FileUtils.mkdir_p(path)
         FileUtils.cp_r("spec/fixtures/template_test", path)
       end
@@ -47,6 +47,17 @@ describe "Admin templates" do
         expect(page).to have_content("A template for participatory processes")
         expect(page).to have_content("1.0.0")
         expect(page).to have_content("Apply in a new participatory space")
+      end
+
+      it "imports an external template" do
+        click_on "External templates"
+        click_on "Apply in a new participatory space"
+
+        check "Include demo data"
+        click_on "Create the new participatory space"
+
+        expect(page).to have_content("The participatory space has been created successfully.")
+        expect(Decidim::ParticipatoryProcess.last.title).to eq({ "en" => "Participatory process title", "ca" => "Títol del procés participatiu", "es" => "" })
       end
     end
 

--- a/spec/system/admin/admin_manages_templates_spec.rb
+++ b/spec/system/admin/admin_manages_templates_spec.rb
@@ -8,6 +8,7 @@ describe "Admin templates" do
   let!(:user) { create(:user, :admin, :confirmed, organization:) }
 
   before do
+    organization.update(available_locales: ["en", "ca", "pt-BR"])
     switch_to_host(organization.host)
     login_as user, scope: :user
 
@@ -57,7 +58,7 @@ describe "Admin templates" do
         click_on "Create the new participatory space"
 
         expect(page).to have_content("The participatory space has been created successfully.")
-        expect(Decidim::ParticipatoryProcess.last.title).to eq({ "en" => "Participatory process title", "ca" => "Títol del procés participatiu", "es" => "" })
+        expect(Decidim::ParticipatoryProcess.last.title).to eq({ "en" => "Participatory process title", "ca" => "Títol del procés participatiu", "pt-BR" => "Título do processo participativo" })
       end
     end
 
@@ -72,8 +73,8 @@ describe "Admin templates" do
       select translated_attribute(participatory_process.title), from: "Select the participatory space you want to use as a template"
       click_on "Create the new template"
 
-      fill_in_i18n(:template_name, "#template-name-tabs", { "ca" => "Nom del template", "es" => "Nombre de la plantilla", "en" => "Template name" })
-      fill_in_i18n(:template_description, "#template-description-tabs", { "ca" => "Descripció del template", "es" => "Descripción de la plantilla", "en" => "Template description" })
+      fill_in_i18n(:template_name, "#template-name-tabs", { "ca" => "Nom del template", "en" => "Template name" })
+      fill_in_i18n(:template_description, "#template-description-tabs", { "ca" => "Descripció del template", "en" => "Template description" })
       fill_in "Version", with: "1.0.0"
       click_on "Create the new template"
 


### PR DESCRIPTION
This PR introduces the use of the template parser and importers.
Combined with #24 it should allow the module to create/export/import the first templates!

<img width="2020" height="1458" alt="image" src="https://github.com/user-attachments/assets/6aa1ee10-8633-4050-a1ee-30362d9664dc" />

- [x] Create base to import
- [x] Import sub-serializations
